### PR TITLE
花火の表示を行うcanvasのサイズを、表示領域の最大値をもとに計算するように変更し、画面サイズが変更されたときに再計算するように変更

### DIFF
--- a/public/js/sketch.js
+++ b/public/js/sketch.js
@@ -2,7 +2,7 @@ var fireworks = [];
 var gravity;
 
 function setup() {
-  createCanvas(displayWidth, displayHeight); // canvasを作成
+  createCanvas(windowWidth, windowHeight); // canvasを作成
   colorMode(HSB); //花火を出す色の指定の仕方
   gravity = createVector(0, 0.7);
   stroke(255); // 線の色を設定
@@ -10,6 +10,10 @@ function setup() {
   background(0); // 背景を黒く指定
 
   frameRate(120);
+}
+
+function windowResized() {
+  resizeCanvas(windowWidth, windowHeight);
 }
 
 function draw() {


### PR DESCRIPTION
`display*`の値を使うと、使用している画面の最大値をもとに計算するので微妙にずれる。
`window*`を使うようにした。

また、画面がリサイズされたときに再計算するように変更。